### PR TITLE
fix xtensa toolchain package find

### DIFF
--- a/src/pioIntegration.ts
+++ b/src/pioIntegration.ts
@@ -462,13 +462,35 @@ function findGdbPackage(packagesDir: string, isRiscV: boolean, chipName?: string
       }
     }
 
-    // Fall back to common variants
+    // Fall back to common variants in the dedicated GDB package
     for (const chip of ['esp32', 'esp32s3', 'esp32s2']) {
       const gdbBin = path.join(gdbDir, `xtensa-${chip}-elf-gdb${ext}`);
       if (fs.existsSync(gdbBin)) {
         return gdbBin;
       }
     }
+
+    // Generic binary (xtensa-esp-elf-gdb) in the dedicated GDB package
+    const genericGdb = path.join(gdbDir, `xtensa-esp-elf-gdb${ext}`);
+    if (fs.existsSync(genericGdb)) {
+      return genericGdb;
+    }
+
+    // Legacy: GDB bundled inside toolchain-xtensa-* packages
+    try {
+      for (const entry of fs.readdirSync(packagesDir)) {
+        if (!entry.startsWith('toolchain-xtensa-')) { continue; }
+        const binDir = path.join(packagesDir, entry, 'bin');
+        if (chipName) {
+          const c = path.join(binDir, `xtensa-${chipName}-elf-gdb${ext}`);
+          if (fs.existsSync(c)) { return c; }
+        }
+        for (const chip of ['esp32', 'esp32s3', 'esp32s2']) {
+          const c = path.join(binDir, `xtensa-${chip}-elf-gdb${ext}`);
+          if (fs.existsSync(c)) { return c; }
+        }
+      }
+    } catch { /* ignore */ }
   }
   return undefined;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved debugger/toolchain discovery to better locate chip-specific binaries across varied toolchain layouts (Xtensa and RISC‑V), with more reliable ROM ELF resolution and target architecture detection.
  * Added an optional chip-specific resolution capability to improve matching without changing existing commands; overall compatibility is maintained and device support is improved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->