### PR TITLE
Auto connect esp device to ESP-Decoder Terminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,6 +145,21 @@
           "default": true,
           "description": "Automatically scroll to bottom on new serial data"
         },
+        "esp-decoder.autoConnect": {
+          "type": "string",
+          "default": "ask",
+          "enum": [
+            "ask",
+            "on",
+            "off"
+          ],
+          "enumDescriptions": [
+            "Ask when an ESP device is detected",
+            "Automatically connect when an ESP device is detected",
+            "Never auto-connect"
+          ],
+          "description": "Automatically connect when an ESP device (Espressif/CP210x/CH340/FTDI) is plugged in"
+        },
         "esp-decoder.monitorLocation": {
           "type": "string",
           "default": "panel",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -554,6 +554,9 @@ async function tryAutoConnectToExisting(
     `[ESP Decoder] ESP device already connected at startup: ${espPort.path} (VID:${espPort.vendorId ?? '?'}, ${espPort.manufacturer ?? 'unknown'})`,
   );
   serial.setPort(espPort.path);
+  if (viewProvider) {
+    viewProvider.syncState();
+  }
   const success = await serial.connect();
   if (success) {
     if (viewProvider) {
@@ -635,6 +638,9 @@ function startUsbPolling(
     // Auto-connect to the detected ESP port.
     log.appendLine(`[ESP Decoder] Auto-connecting to ${espPort.path}`);
     serial.setPort(espPort.path);
+    if (viewProvider) {
+      viewProvider.syncState();
+    }
     const success = await serial.connect();
     if (success) {
       // Ensure the webview reflects the new connection state (e.g. when the

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,8 @@ interface PioarduinoApi {
 let serialManager: SerialPortManager;
 let viewProvider: EspDecoderWebviewPanel | undefined;
 let outputChannel: vscode.OutputChannel;
+let usbPollingTimer: ReturnType<typeof setInterval> | undefined;
+let knownPorts: Set<string> = new Set();
 
 // Session state
 let sessionConfig: SessionConfig = {};
@@ -160,6 +162,9 @@ export function activate(context: vscode.ExtensionContext) {
       // This is handled by the webview
     })
   );
+
+  // Start USB device polling for auto-connect
+  startUsbPolling(context, serialManager, outputChannel);
 
   // Auto-detect ELF on activation if configured
   const config = vscode.workspace.getConfiguration('esp-decoder');
@@ -497,6 +502,114 @@ function isEspIdfBuildElf(elfPath: string): boolean {
 
   const lower = elfPath.toLowerCase();
   return lower.endsWith('.elf') && !lower.endsWith('/bootloader.elf') && !lower.endsWith('/partition-table.elf') && !lower.endsWith('\\bootloader.elf') && !lower.endsWith('\\partition-table.elf');
+}
+
+/**
+ * Known USB Vendor IDs for common ESP-compatible USB-to-serial chips.
+ */
+const ESP_VENDOR_IDS = new Set([
+  '303a', // Espressif (ESP32-S2/S3/C3/C6 native USB)
+  '10c4', // Silicon Labs CP210x
+  '1a86', // QinHeng CH340/CH341
+  '0403', // FTDI FT232/FT2232
+]);
+
+function isEspDevice(port: { vendorId?: string; manufacturer?: string }): boolean {
+  if (port.vendorId && ESP_VENDOR_IDS.has(port.vendorId.toLowerCase())) {
+    return true;
+  }
+  if (port.manufacturer) {
+    const mfr = port.manufacturer.toLowerCase();
+    return mfr.includes('espressif') || mfr.includes('silicon labs')
+      || mfr.includes('cp210') || mfr.includes('ch340')
+      || mfr.includes('ftdi') || mfr.includes('wch');
+  }
+  return false;
+}
+
+/**
+ * Poll for newly attached USB serial ports.  When a probable ESP device
+ * appears, either auto-connect (if the user opted in) or ask the user
+ * once whether auto-connect should be enabled.
+ */
+function startUsbPolling(
+  context: vscode.ExtensionContext,
+  serial: SerialPortManager,
+  log: vscode.OutputChannel,
+): void {
+  // Seed the set of already-known ports so we only react to *new* ones.
+  serial.listPorts().then((ports) => {
+    for (const p of ports) {
+      knownPorts.add(p.path);
+    }
+  });
+
+  usbPollingTimer = setInterval(async () => {
+    // Don't auto-connect while already connected.
+    if (serial.isConnected) {
+      return;
+    }
+
+    const config = vscode.workspace.getConfiguration('esp-decoder');
+    const autoConnect = config.get<string>('autoConnect', 'ask');
+    if (autoConnect === 'off') {
+      return;
+    }
+
+    const ports = await serial.listPorts();
+    const currentPaths = new Set(ports.map((p) => p.path));
+
+    // Detect newly appeared ports.
+    const newPorts = ports.filter((p) => !knownPorts.has(p.path));
+
+    // Update known set (also removes ports that disappeared).
+    knownPorts = currentPaths;
+
+    const espPort = newPorts.find((p) => isEspDevice(p));
+    if (!espPort) {
+      return;
+    }
+
+    log.appendLine(
+      `[ESP Decoder] ESP device detected: ${espPort.path} (VID:${espPort.vendorId ?? '?'}, ${espPort.manufacturer ?? 'unknown'})`,
+    );
+
+    if (autoConnect === 'ask') {
+      const choice = await vscode.window.showInformationMessage(
+        `ESP device detected on ${espPort.path}. Enable auto-connect for future devices?`,
+        'Yes, connect now',
+        'No, never',
+      );
+      if (choice === 'Yes, connect now') {
+        await config.update('autoConnect', 'on', vscode.ConfigurationTarget.Global);
+        log.appendLine('[ESP Decoder] Auto-connect enabled by user');
+      } else if (choice === 'No, never') {
+        await config.update('autoConnect', 'off', vscode.ConfigurationTarget.Global);
+        log.appendLine('[ESP Decoder] Auto-connect disabled by user');
+        return;
+      } else {
+        // Dismissed — don't connect, don't persist, ask again next time
+        return;
+      }
+    }
+
+    // Auto-connect to the detected ESP port.
+    log.appendLine(`[ESP Decoder] Auto-connecting to ${espPort.path}`);
+    serial.setPort(espPort.path);
+    const success = await serial.connect();
+    if (success) {
+      vscode.window.showInformationMessage(
+        `ESP Decoder: Auto-connected to ${espPort.path} @ ${serial.baudRate}`,
+      );
+    }
+  }, 2000);
+
+  context.subscriptions.push(new vscode.Disposable(() => {
+    if (usbPollingTimer) {
+      clearInterval(usbPollingTimer);
+      usbPollingTimer = undefined;
+    }
+  }));
 }
 
 export function deactivate(): void {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -528,6 +528,44 @@ function isEspDevice(port: { vendorId?: string; manufacturer?: string }): boolea
 }
 
 /**
+ * On startup, check if an ESP device is already connected and auto-connect
+ * if the user previously opted in.
+ */
+async function tryAutoConnectToExisting(
+  serial: SerialPortManager,
+  log: vscode.OutputChannel,
+  ports: import('./serialPortManager').SerialPortInfo[],
+): Promise<void> {
+  if (serial.isConnected) {
+    return;
+  }
+  const config = vscode.workspace.getConfiguration('esp-decoder');
+  const autoConnect = config.get<string>('autoConnect', 'ask');
+  if (autoConnect !== 'on') {
+    return;
+  }
+
+  const espPort = ports.find((p) => isEspDevice(p));
+  if (!espPort) {
+    return;
+  }
+
+  log.appendLine(
+    `[ESP Decoder] ESP device already connected at startup: ${espPort.path} (VID:${espPort.vendorId ?? '?'}, ${espPort.manufacturer ?? 'unknown'})`,
+  );
+  serial.setPort(espPort.path);
+  const success = await serial.connect();
+  if (success) {
+    if (viewProvider) {
+      viewProvider.syncState();
+    }
+    vscode.window.showInformationMessage(
+      `ESP Decoder: Auto-connected to ${espPort.path} @ ${serial.baudRate}`,
+    );
+  }
+}
+
+/**
  * Poll for newly attached USB serial ports.  When a probable ESP device
  * appears, either auto-connect (if the user opted in) or ask the user
  * once whether auto-connect should be enabled.
@@ -537,11 +575,12 @@ function startUsbPolling(
   serial: SerialPortManager,
   log: vscode.OutputChannel,
 ): void {
-  // Seed the set of already-known ports so we only react to *new* ones.
-  serial.listPorts().then((ports) => {
+  // Check for already-connected ESP devices on startup.
+  serial.listPorts().then(async (ports) => {
     for (const p of ports) {
       knownPorts.add(p.path);
     }
+    await tryAutoConnectToExisting(serial, log, ports);
   });
 
   usbPollingTimer = setInterval(async () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -598,6 +598,11 @@ function startUsbPolling(
     serial.setPort(espPort.path);
     const success = await serial.connect();
     if (success) {
+      // Ensure the webview reflects the new connection state (e.g. when the
+      // panel was already visible but missed the connectionChanged event).
+      if (viewProvider) {
+        viewProvider.syncState();
+      }
       vscode.window.showInformationMessage(
         `ESP Decoder: Auto-connected to ${espPort.path} @ ${serial.baudRate}`,
       );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,7 @@ let viewProvider: EspDecoderWebviewPanel | undefined;
 let outputChannel: vscode.OutputChannel;
 let usbPollingTimer: ReturnType<typeof setInterval> | undefined;
 let knownPorts: Set<string> = new Set();
+let isUploading = false;
 
 // Session state
 let sessionConfig: SessionConfig = {};
@@ -420,6 +421,7 @@ function subscribeToPioarduinoEvents(
         );
 
         // Tell pioarduino to wait until we have fully released the port.
+        isUploading = true;
         waitUntil(serial.releasePort());
       }),
     );
@@ -429,7 +431,11 @@ function subscribeToPioarduinoEvents(
         log.appendLine(
           `[ESP Decoder] onDidUpload (port=${port ?? 'auto'}, exitCode=${exitCode}) — reacquiring serial port`,
         );
-        await reacquireWithRetry(serial, log);
+        try {
+          await reacquireWithRetry(serial, log);
+        } finally {
+          isUploading = false;
+        }
       }),
     );
   }).catch((err) => {
@@ -592,8 +598,8 @@ function startUsbPolling(
   });
 
   usbPollingTimer = setInterval(async () => {
-    // Don't auto-connect while already connected.
-    if (serial.isConnected) {
+    // Don't auto-connect while already connected or during an upload.
+    if (serial.isConnected || isUploading) {
       return;
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -578,12 +578,17 @@ function startUsbPolling(
   serial: SerialPortManager,
   log: vscode.OutputChannel,
 ): void {
+  let consecutiveFailures = 0;
+  const MAX_POLL_FAILURES = 5;
+
   // Check for already-connected ESP devices on startup.
-  serial.listPorts().then(async (ports) => {
+  serial.listPortsSilent().then(async (ports) => {
     for (const p of ports) {
       knownPorts.add(p.path);
     }
     await tryAutoConnectToExisting(serial, log, ports);
+  }).catch((err) => {
+    log.appendLine(`[ESP Decoder] Failed to list ports on startup: ${err instanceof Error ? err.message : err}`);
   });
 
   usbPollingTimer = setInterval(async () => {
@@ -598,7 +603,23 @@ function startUsbPolling(
       return;
     }
 
-    const ports = await serial.listPorts();
+    let ports: import('./serialPortManager').SerialPortInfo[];
+    try {
+      ports = await serial.listPortsSilent();
+      consecutiveFailures = 0;
+    } catch (err) {
+      consecutiveFailures++;
+      log.appendLine(
+        `[ESP Decoder] Port scan failed (${consecutiveFailures}/${MAX_POLL_FAILURES}): ${err instanceof Error ? err.message : err}`,
+      );
+      if (consecutiveFailures >= MAX_POLL_FAILURES && usbPollingTimer) {
+        clearInterval(usbPollingTimer);
+        usbPollingTimer = undefined;
+        log.appendLine('[ESP Decoder] USB polling disabled after repeated failures');
+      }
+      return;
+    }
+
     const currentPaths = new Set(ports.map((p) => p.path));
 
     // Detect newly appeared ports.

--- a/src/serialPortManager.ts
+++ b/src/serialPortManager.ts
@@ -49,21 +49,30 @@ export class SerialPortManager extends vscode.Disposable {
 
   async listPorts(): Promise<SerialPortInfo[]> {
     try {
-      const ports = await SerialPort.list();
-      return ports.map((p) => ({
-        path: p.path,
-        manufacturer: p.manufacturer,
-        serialNumber: p.serialNumber,
-        vendorId: p.vendorId,
-        productId: p.productId,
-        friendlyName: p.friendlyName,
-      }));
+      return await this.listPortsSilent();
     } catch (err) {
       vscode.window.showErrorMessage(
         `Failed to list serial ports: ${err instanceof Error ? err.message : err}`
       );
       return [];
     }
+  }
+
+  /**
+   * List serial ports without showing any UI on failure.
+   * Intended for background polling where errors should only be logged.
+   * Throws on failure instead of swallowing the error.
+   */
+  async listPortsSilent(): Promise<SerialPortInfo[]> {
+    const ports = await SerialPort.list();
+    return ports.map((p) => ({
+      path: p.path,
+      manufacturer: p.manufacturer,
+      serialNumber: p.serialNumber,
+      vendorId: p.vendorId,
+      productId: p.productId,
+      friendlyName: p.friendlyName,
+    }));
   }
 
   setPort(portPath: string): void {

--- a/src/serialPortManager.ts
+++ b/src/serialPortManager.ts
@@ -66,6 +66,10 @@ export class SerialPortManager extends vscode.Disposable {
     }
   }
 
+  setPort(portPath: string): void {
+    this._selectedPath = portPath;
+  }
+
   async selectPort(): Promise<string | undefined> {
     const ports = await this.listPorts();
     if (ports.length === 0) {

--- a/src/serialPortManager.ts
+++ b/src/serialPortManager.ts
@@ -161,9 +161,16 @@ export class SerialPortManager extends vscode.Disposable {
 
       this.port.open((err) => {
         if (err) {
-          vscode.window.showErrorMessage(
-            `Failed to open ${this._selectedPath}: ${err.message}`
-          );
+          const msg = err.message || '';
+          if (msg.includes('temporarily unavailable') || msg.includes('lock') || msg.includes('busy') || msg.includes('Access denied')) {
+            vscode.window.showWarningMessage(
+              `Port ${this._selectedPath} is already in use by another application or VS Code window.`
+            );
+          } else {
+            vscode.window.showErrorMessage(
+              `Failed to open ${this._selectedPath}: ${msg}`
+            );
+          }
           this.port = null;
           resolve(false);
           return;

--- a/src/webviewPanel.ts
+++ b/src/webviewPanel.ts
@@ -208,7 +208,7 @@ export class EspDecoderWebviewPanel implements vscode.WebviewViewProvider {
     this.syncState();
   }
 
-  private syncState(): void {
+  public syncState(): void {
     this.postMessage({
       type: 'initialState',
       connected: this.serialManager.isConnected,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic ESP device detection and connection with a new configurable setting (ask/on/off) to control auto-connect behavior
  * Continuous USB port monitoring to detect when ESP devices are plugged in or removed
  * Prompting flow that can persist your choice for newly detected devices

* **Bug Fixes**
  * Improved messages for serial port connection errors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->