### PR TITLE
feature: reconnect when device is external reseted

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,6 +161,11 @@
           "default": 15000,
           "description": "Maximum time (in milliseconds) to keep polling for the device to reappear before giving up auto-reconnect."
         },
+        "esp-decoder.debugLogging": {
+          "type": "boolean",
+          "default": false,
+          "description": "Emit verbose diagnostic messages (e.g. internal state of the serial-port manager, auto-reconnect classification) to the ESP Decoder output channel. Enable when troubleshooting; leave off for normal use."
+        },
         "esp-decoder.logDirectory": {
           "type": "string",
           "default": "logs",

--- a/package.json
+++ b/package.json
@@ -161,11 +161,6 @@
           "default": 15000,
           "description": "Maximum time (in milliseconds) to keep polling for the device to reappear before giving up auto-reconnect."
         },
-        "esp-decoder.debugLogging": {
-          "type": "boolean",
-          "default": false,
-          "description": "Emit verbose diagnostic messages (e.g. internal state of the serial-port manager, auto-reconnect classification) to the ESP Decoder output channel. Enable when troubleshooting; leave off for normal use."
-        },
         "esp-decoder.logDirectory": {
           "type": "string",
           "default": "logs",
@@ -209,6 +204,11 @@
           "minimum": 1,
           "default": 3,
           "description": "Number of regex matches to show before collapsing repeated characters (dedupPattern)"
+        },
+        "esp-decoder.debugLogging": {
+          "type": "boolean",
+          "default": false,
+          "description": "Emit verbose diagnostic messages (e.g. internal state of the serial-port manager, auto-reconnect classification) to the ESP Decoder output channel. Enable when troubleshooting; leave off for normal use."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -150,6 +150,17 @@
           "default": true,
           "description": "Automatically scroll to bottom on new serial data"
         },
+        "esp-decoder.serialMonitor.autoReconnect": {
+          "type": "boolean",
+          "default": false,
+          "description": "Automatically reconnect to the serial port if it disappears (e.g. during reset on boards with native USB-CDC such as ESP32-S2/S3/C3). Reconnection only occurs when a port reappears with the same VID/PID/serialNumber as the originally connected device."
+        },
+        "esp-decoder.serialMonitor.autoReconnectTimeoutMs": {
+          "type": "integer",
+          "minimum": 1000,
+          "default": 15000,
+          "description": "Maximum time (in milliseconds) to keep polling for the device to reappear before giving up auto-reconnect."
+        },
         "esp-decoder.logDirectory": {
           "type": "string",
           "default": "logs",

--- a/src/serialPortManager.ts
+++ b/src/serialPortManager.ts
@@ -281,25 +281,30 @@ export class SerialPortManager extends vscode.Disposable {
           this._onData.fire(data);
         });
         this._isConnected = true;
-        // Capture device identity for VID/PID/serialNumber-matching reconnect.
-        this.captureDeviceIdentity().catch(() => {
-          /* best effort — identity is only used for auto-reconnect matching */
-        });
-        // If this open happened inside a reconnect window, arm the stability
-        // timer. The window only ends if the port stays open for STABILITY_MS.
-        if (this._isReconnecting) {
-          this.clearStabilityTimer();
-          this._stabilityTimer = setTimeout(() => {
-            this._stabilityTimer = null;
-            if (this._isConnected) {
-              this._isReconnecting = false;
-              this._reconnectDeadline = 0;
-              this.log.appendLine('[ESP Decoder] auto-reconnect: connection stable');
+        // Capture device identity BEFORE firing connection-change / resolving,
+        // so that an immediate reset (within a few hundred ms of connect)
+        // still finds VID/PID/SN populated when startAutoReconnect runs.
+        // This is awaited but typically completes in <100 ms.
+        void this.captureDeviceIdentity()
+          .catch(() => { /* best effort — identity used only for reconnect matching */ })
+          .then(() => {
+            // If this open happened inside a reconnect window, arm the
+            // stability timer. The window only ends if the port stays open
+            // for STABILITY_MS without a close.
+            if (this._isReconnecting) {
+              this.clearStabilityTimer();
+              this._stabilityTimer = setTimeout(() => {
+                this._stabilityTimer = null;
+                if (this._isConnected) {
+                  this._isReconnecting = false;
+                  this._reconnectDeadline = 0;
+                  this.log.appendLine('[ESP Decoder] auto-reconnect: connection stable');
+                }
+              }, SerialPortManager.STABILITY_MS);
             }
-          }, SerialPortManager.STABILITY_MS);
-        }
-        this._onConnectionChange.fire(true);
-        resolve(true);
+            this._onConnectionChange.fire(true);
+            resolve(true);
+          });
       });
     });
   }
@@ -509,6 +514,11 @@ export class SerialPortManager extends vscode.Disposable {
         this.log.appendLine('[ESP Decoder] auto-reconnect: timed out waiting for device');
         this._isReconnecting = false;
         this._reconnectDeadline = 0;
+        // Surface the failure so the user knows reconnection gave up rather
+        // than silently never coming back.
+        vscode.window.showWarningMessage(
+          `ESP Decoder: auto-reconnect timed out — device with VID=${targetVid ?? '?'} PID=${targetPid ?? '?'} did not reappear.`
+        );
         return;
       }
       let ports: SerialPortInfo[] = [];
@@ -590,17 +600,22 @@ export class SerialPortManager extends vscode.Disposable {
  * they're swallowed so the monitor stays quiet until either a stable
  * connection forms or the reconnect deadline expires.
  */
-function isTransientReconnectError(err: Error): boolean {
+export function isTransientReconnectError(err: Error): boolean {
   const msg = err.message.toLowerCase();
   // POSIX: ENXIO (no such device), EIO (input/output error), ENOENT,
   // EBADF (bad file descriptor), ENODEV (no such device), EAGAIN.
   // macOS: "device not configured".
-  // Windows: "access denied", "operation aborted", "the device does not
-  // recognize the command", "the i/o operation has been aborted".
+  // Windows: "operation aborted", "the device does not recognize the command",
+  // "the i/o operation has been aborted", "cannot find the file specified".
+  //
+  // NOTE: "access denied" is intentionally NOT suppressed. On Windows it
+  // typically means another process is holding the port (bootloader tool,
+  // Zadig, another serial monitor) — that is actionable for the user, and
+  // silently swallowing it during a reconnect window would hide the real
+  // reason reconnection never succeeds.
   return /\b(enxio|eio|enoent|ebadf|enodev|eagain|eacces)\b/.test(msg)
     || msg.includes('no such device')
     || msg.includes('device not configured')
-    || msg.includes('access denied')
     || msg.includes('operation aborted')
     || msg.includes('i/o operation has been aborted')
     || msg.includes('does not recognize the command')

--- a/src/serialPortManager.ts
+++ b/src/serialPortManager.ts
@@ -219,8 +219,8 @@ export class SerialPortManager extends vscode.Disposable {
       }
 
       this.port.on('error', (err: Error) => {
-        if (this._isReconnecting && isTransientReconnectError(err)) {
-          this.log.appendLine(`[ESP Decoder] suppressed transient error during reconnect: ${err.message}`);
+        if (this.shouldSuppressTransient(err)) {
+          this.log.appendLine(`[ESP Decoder] suppressed transient error (auto-reconnect): ${err.message}`);
           return;
         }
         this._onError.fire(err);
@@ -230,8 +230,8 @@ export class SerialPortManager extends vscode.Disposable {
         // Cancel any pending stability check — connection didn't last.
         this.clearStabilityTimer();
         if (disconnectError) {
-          if (this._isReconnecting && isTransientReconnectError(disconnectError)) {
-            this.log.appendLine(`[ESP Decoder] suppressed transient close error during reconnect: ${disconnectError.message}`);
+          if (this.shouldSuppressTransient(disconnectError)) {
+            this.log.appendLine(`[ESP Decoder] suppressed transient close error (auto-reconnect): ${disconnectError.message}`);
           } else {
             this._onError.fire(disconnectError);
           }
@@ -307,6 +307,30 @@ export class SerialPortManager extends vscode.Disposable {
       clearTimeout(this._reconnectTimer);
       this._reconnectTimer = null;
     }
+  }
+
+  /**
+   * True if a transient I/O error (ENXIO/EIO/etc.) should be swallowed instead
+   * of surfaced to the user. Suppression applies whenever the auto-reconnect
+   * setting is enabled, even for the very first error of a reset cycle —
+   * before {@link startAutoReconnect} has been called — so the user never sees
+   * a stray "ENXIO: no such device" toast for a reset they expect to recover.
+   */
+  private shouldSuppressTransient(err: Error): boolean {
+    if (!isTransientReconnectError(err)) {
+      return false;
+    }
+    if (this._isReconnecting) {
+      return true;
+    }
+    return this.isAutoReconnectEnabled();
+  }
+
+  /** Read the current auto-reconnect setting from the workspace config. */
+  private isAutoReconnectEnabled(): boolean {
+    return vscode.workspace
+      .getConfiguration('esp-decoder')
+      .get<boolean>('serialMonitor.autoReconnect', false);
   }
 
   /** Look up and cache VID/PID/serialNumber for the currently connected port. */

--- a/src/serialPortManager.ts
+++ b/src/serialPortManager.ts
@@ -10,6 +10,13 @@ export interface SerialPortInfo {
   friendlyName?: string;
 }
 
+export interface DisconnectInfo {
+  /** True when the user explicitly requested the disconnect (UI button / command). */
+  userInitiated: boolean;
+  /** True when the disconnect was triggered by releasePort() for an upload. */
+  suspended: boolean;
+}
+
 export class SerialPortManager extends vscode.Disposable {
   private port: SerialPort | null = null;
   private _selectedPath: string | undefined;
@@ -17,6 +24,21 @@ export class SerialPortManager extends vscode.Disposable {
   private _isConnected = false;
   private readonly log: vscode.OutputChannel;
   private readonly ownsLog: boolean;
+
+  // Identity of the currently/last connected device — used to match the same
+  // physical board when it re-enumerates (e.g. native USB-CDC after reset).
+  private _connectedVendorId: string | undefined;
+  private _connectedProductId: string | undefined;
+  private _connectedSerialNumber: string | undefined;
+
+  // Disconnect intent flags — read by listeners on the next 'connectionChange'
+  // event to decide whether an unexpected close should trigger auto-reconnect.
+  private _userInitiatedDisconnect = false;
+  private _suppressErrorToasts = false;
+
+  // Auto-reconnect polling state
+  private _reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private _reconnectDeadline = 0;
 
   private readonly _onData = new vscode.EventEmitter<Buffer>();
   readonly onData = this._onData.event;
@@ -26,6 +48,10 @@ export class SerialPortManager extends vscode.Disposable {
 
   private readonly _onConnectionChange = new vscode.EventEmitter<boolean>();
   readonly onConnectionChange = this._onConnectionChange.event;
+
+  private readonly _onDisconnect = new vscode.EventEmitter<DisconnectInfo>();
+  /** Fired immediately after a transition to disconnected, with intent info. */
+  readonly onDisconnect = this._onDisconnect.event;
 
   // State for temporary port release (e.g., during pioarduino upload)
   private _suspendedPath: string | undefined;
@@ -143,6 +169,10 @@ export class SerialPortManager extends vscode.Disposable {
       }
     }
 
+    // A successful or attempted connect cancels any in-flight auto-reconnect
+    // loop; we are intentionally taking control of the port now.
+    this.cancelReconnect();
+
     return new Promise<boolean>((resolve) => {
       this.log.appendLine(`[ESP Decoder] Creating SerialPort instance for ${this._selectedPath} @ ${this._baudRate}`);
       try {
@@ -156,9 +186,11 @@ export class SerialPortManager extends vscode.Disposable {
         );
       } catch (err) {
         this.log.appendLine(`[ESP Decoder] Failed to create SerialPort: ${err instanceof Error ? err.message : err}`);
-        vscode.window.showErrorMessage(
-          `Failed to create serial port: ${err instanceof Error ? err.message : err}`
-        );
+        if (!this._suppressErrorToasts) {
+          vscode.window.showErrorMessage(
+            `Failed to create serial port: ${err instanceof Error ? err.message : err}`
+          );
+        }
         this.port = null;
         resolve(false);
         return;
@@ -175,15 +207,25 @@ export class SerialPortManager extends vscode.Disposable {
         this.port = null;
         if (this._isConnected) {
           this._isConnected = false;
+          const info: DisconnectInfo = {
+            userInitiated: this._userInitiatedDisconnect,
+            suspended: this._suspendedPath !== undefined,
+          };
+          // Reset the intent flag so the next close (e.g. unexpected USB drop)
+          // is correctly classified as not user-initiated.
+          this._userInitiatedDisconnect = false;
           this._onConnectionChange.fire(false);
+          this._onDisconnect.fire(info);
         }
       });
 
       this.port.open((err) => {
         if (err) {
-          vscode.window.showErrorMessage(
-            `Failed to open ${this._selectedPath}: ${err.message}`
-          );
+          if (!this._suppressErrorToasts) {
+            vscode.window.showErrorMessage(
+              `Failed to open ${this._selectedPath}: ${err.message}`
+            );
+          }
           this.port = null;
           resolve(false);
           return;
@@ -194,26 +236,58 @@ export class SerialPortManager extends vscode.Disposable {
           this._onData.fire(data);
         });
         this._isConnected = true;
+        // Capture device identity for VID/PID/serialNumber-matching reconnect.
+        this.captureDeviceIdentity().catch(() => {
+          /* best effort — identity is only used for auto-reconnect matching */
+        });
         this._onConnectionChange.fire(true);
         resolve(true);
       });
     });
   }
 
+  /** Look up and cache VID/PID/serialNumber for the currently connected port. */
+  private async captureDeviceIdentity(): Promise<void> {
+    if (!this._selectedPath) {
+      return;
+    }
+    try {
+      const ports = await SerialPort.list();
+      const match = ports.find((p) => p.path === this._selectedPath);
+      if (match) {
+        this._connectedVendorId = match.vendorId;
+        this._connectedProductId = match.productId;
+        this._connectedSerialNumber = match.serialNumber;
+        this.log.appendLine(
+          `[ESP Decoder] Connected device identity: VID=${match.vendorId ?? '?'} PID=${match.productId ?? '?'} SN=${match.serialNumber ?? '?'}`
+        );
+      }
+    } catch {
+      /* ignore — identity capture is best-effort */
+    }
+  }
+
   async disconnect(): Promise<void> {
+    // Cancel any pending auto-reconnect — an explicit disconnect always wins.
+    this.cancelReconnect();
+    this._userInitiatedDisconnect = true;
     return new Promise<void>((resolve, reject) => {
       if (!this.port || !this._isConnected) {
         this._isConnected = false;
+        this._userInitiatedDisconnect = false;
         this._onConnectionChange.fire(false);
+        this._onDisconnect.fire({ userInitiated: true, suspended: false });
         resolve();
         return;
       }
 
       this.port.close((err) => {
         if (err) {
+          // Reset the intent flag on failure so we don't lie about the next close.
+          this._userInitiatedDisconnect = false;
           reject(err);
         } else {
-          // The 'close' event handler will set _isConnected and fire the event
+          // The 'close' event handler will set _isConnected and fire the events
           resolve();
         }
       });
@@ -282,15 +356,135 @@ export class SerialPortManager extends vscode.Disposable {
     this._suspendedBaudRate = undefined;
   }
 
+  /**
+   * Begin polling for the previously connected device to reappear, then
+   * reconnect to it. The poll only matches a port whose VID/PID/serialNumber
+   * exactly equal the values captured at the most recent successful connect,
+   * so a different device plugged in afterwards is never auto-attached.
+   *
+   * Safe to call repeatedly — only one polling loop runs at a time.
+   * Cancelled automatically by {@link connect}, {@link disconnect}, and
+   * {@link dispose}.
+   *
+   * @param timeoutMs Total wall-clock budget for polling.
+   * @param pollIntervalMs Delay between port-list polls.
+   */
+  startAutoReconnect(timeoutMs: number, pollIntervalMs = 500): void {
+    if (this._reconnectTimer) {
+      // Already running — don't stack timers.
+      return;
+    }
+    if (this._isConnected) {
+      return;
+    }
+    if (!this._connectedVendorId && !this._connectedProductId && !this._connectedSerialNumber) {
+      this.log.appendLine('[ESP Decoder] auto-reconnect skipped: no device identity captured');
+      return;
+    }
+    const targetVid = this._connectedVendorId;
+    const targetPid = this._connectedProductId;
+    const targetSn = this._connectedSerialNumber;
+    const previousPath = this._selectedPath;
+    this._reconnectDeadline = Date.now() + timeoutMs;
+    this.log.appendLine(
+      `[ESP Decoder] auto-reconnect armed: VID=${targetVid ?? '?'} PID=${targetPid ?? '?'} SN=${targetSn ?? '?'} timeout=${timeoutMs}ms`
+    );
+
+    const poll = async (): Promise<void> => {
+      this._reconnectTimer = null;
+      if (this._isConnected) {
+        return;
+      }
+      if (Date.now() > this._reconnectDeadline) {
+        this.log.appendLine('[ESP Decoder] auto-reconnect: timed out waiting for device');
+        return;
+      }
+      let ports: SerialPortInfo[] = [];
+      try {
+        ports = await this.listPorts();
+      } catch {
+        ports = [];
+      }
+      const match = ports.find((p) =>
+        portIdentityMatches(p, targetVid, targetPid, targetSn)
+      );
+      if (match) {
+        this.log.appendLine(
+          `[ESP Decoder] auto-reconnect: matched device at ${match.path} (was ${previousPath ?? '?'})`
+        );
+        this._selectedPath = match.path;
+        this._suppressErrorToasts = true;
+        try {
+          const ok = await this.connect();
+          if (!ok) {
+            // Open failed (device may not be fully ready) — try again.
+            this._reconnectTimer = setTimeout(() => { void poll(); }, pollIntervalMs);
+          }
+        } finally {
+          this._suppressErrorToasts = false;
+        }
+        return;
+      }
+      this._reconnectTimer = setTimeout(() => { void poll(); }, pollIntervalMs);
+    };
+
+    // First poll runs after a short delay to give the OS time to enumerate.
+    this._reconnectTimer = setTimeout(() => { void poll(); }, pollIntervalMs);
+  }
+
+  /** Cancel any in-flight auto-reconnect polling loop. */
+  cancelReconnect(): void {
+    if (this._reconnectTimer) {
+      clearTimeout(this._reconnectTimer);
+      this._reconnectTimer = null;
+    }
+    this._reconnectDeadline = 0;
+  }
+
   dispose(): void {
+    this.cancelReconnect();
     if (this.port && this._isConnected) {
       this.port.close();
     }
     this._onData.dispose();
     this._onError.dispose();
     this._onConnectionChange.dispose();
+    this._onDisconnect.dispose();
     if (this.ownsLog) {
       this.log.dispose();
     }
   }
+}
+
+/**
+ * Returns true when `port` has the same VID, PID, and serialNumber as the
+ * given target identity. At least one of the three target fields must be
+ * defined, and every defined target field must match exactly. This avoids
+ * matching a different device that happens to enumerate at the same path.
+ */
+function portIdentityMatches(
+  port: SerialPortInfo,
+  vendorId: string | undefined,
+  productId: string | undefined,
+  serialNumber: string | undefined
+): boolean {
+  const targets: Array<[string | undefined, string | undefined]> = [
+    [vendorId, port.vendorId],
+    [productId, port.productId],
+    [serialNumber, port.serialNumber],
+  ];
+  let anyDefined = false;
+  for (const [target, actual] of targets) {
+    if (target === undefined) {
+      continue;
+    }
+    anyDefined = true;
+    if (actual === undefined) {
+      return false;
+    }
+    if (target.toLowerCase() !== actual.toLowerCase()) {
+      return false;
+    }
+  }
+  return anyDefined;
 }

--- a/src/serialPortManager.ts
+++ b/src/serialPortManager.ts
@@ -111,7 +111,7 @@ export class SerialPortManager extends vscode.Disposable {
     return ports;
   }
 
-  async listPorts(): Promise<SerialPortInfo[]> {
+  async listPorts(suppressToasts = false): Promise<SerialPortInfo[]> {
     try {
       const ports = await SerialPort.list();
       const mappedPorts = ports.map((p) => ({
@@ -124,9 +124,18 @@ export class SerialPortManager extends vscode.Disposable {
       }));
       return this.filterPorts(mappedPorts);
     } catch (err) {
-      vscode.window.showErrorMessage(
-        `Failed to list serial ports: ${err instanceof Error ? err.message : err}`
-      );
+      // Background callers (auto-reconnect poll, identity capture) pass
+      // suppressToasts=true so a transient enumeration failure does not flood
+      // the user with modal error messages mid-reset cycle.
+      if (!suppressToasts) {
+        vscode.window.showErrorMessage(
+          `Failed to list serial ports: ${err instanceof Error ? err.message : err}`
+        );
+      } else {
+        this.log.appendLine(
+          `[ESP Decoder] listPorts failed (suppressed): ${err instanceof Error ? err.message : err}`
+        );
+      }
       return [];
     }
   }
@@ -339,7 +348,8 @@ export class SerialPortManager extends vscode.Disposable {
       return;
     }
     try {
-      const ports = await SerialPort.list();
+      // Background lookup — never raise toasts on enumeration failure.
+      const ports = await this.listPorts(/* suppressToasts */ true);
       const match = ports.find((p) => p.path === this._selectedPath);
       if (match) {
         this._connectedVendorId = match.vendorId;
@@ -503,9 +513,16 @@ export class SerialPortManager extends vscode.Disposable {
       }
       let ports: SerialPortInfo[] = [];
       try {
-        ports = await this.listPorts();
+        ports = await this.listPorts(/* suppressToasts */ true);
       } catch {
         ports = [];
+      }
+      // Re-check the reconnect guard after the await: cancelReconnect() or
+      // disconnect() may have run while we were enumerating ports, in which
+      // case we must not mutate _selectedPath / _suppressErrorToasts or call
+      // connect() — that would silently undo the user's cancel.
+      if (!this._isReconnecting || this._isConnected) {
+        return;
       }
       const match = ports.find((p) =>
         portIdentityMatches(p, targetVid, targetPid, targetSn)

--- a/src/serialPortManager.ts
+++ b/src/serialPortManager.ts
@@ -39,6 +39,20 @@ export class SerialPortManager extends vscode.Disposable {
   // Auto-reconnect polling state
   private _reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private _reconnectDeadline = 0;
+  // True from the moment startAutoReconnect() arms a reconnect window until
+  // either a stable connection is established, the deadline elapses, or the
+  // user/dispose explicitly cancels it. Used to:
+  //   1. preserve the original deadline across multiple unstable reset cycles
+  //      (the user may need to press the reset button several times);
+  //   2. silently swallow benign read/close errors (ENXIO/EIO/...) that the OS
+  //      reports while a native USB-CDC device is re-enumerating.
+  private _isReconnecting = false;
+  // Set after each successful (re)connect during a reconnect window. If the
+  // port stays open for STABILITY_MS without closing, the reconnect window
+  // ends. If the port closes first, the timer is cancelled and the existing
+  // deadline continues to apply to the next attempt.
+  private _stabilityTimer: ReturnType<typeof setTimeout> | null = null;
+  private static readonly STABILITY_MS = 1500;
 
   private readonly _onData = new vscode.EventEmitter<Buffer>();
   readonly onData = this._onData.event;
@@ -75,6 +89,11 @@ export class SerialPortManager extends vscode.Disposable {
 
   get isConnected(): boolean {
     return this._isConnected;
+  }
+
+  /** True while an auto-reconnect window is active. */
+  get isReconnecting(): boolean {
+    return this._isReconnecting;
   }
 
   public filterPorts<T extends { path: string; manufacturer?: string }>(
@@ -169,9 +188,12 @@ export class SerialPortManager extends vscode.Disposable {
       }
     }
 
-    // A successful or attempted connect cancels any in-flight auto-reconnect
-    // loop; we are intentionally taking control of the port now.
-    this.cancelReconnect();
+    // Clear any pending poll timer — we are taking control of the port now.
+    // Note: we deliberately do NOT clear `_isReconnecting` here, because this
+    // method is itself called from the reconnect poll, and we want the window
+    // (and its deadline) to survive until either a stable connection forms or
+    // the user cancels. cancelReconnect() handles full teardown when needed.
+    this.clearReconnectTimer();
 
     return new Promise<boolean>((resolve) => {
       this.log.appendLine(`[ESP Decoder] Creating SerialPort instance for ${this._selectedPath} @ ${this._baudRate}`);
@@ -197,12 +219,22 @@ export class SerialPortManager extends vscode.Disposable {
       }
 
       this.port.on('error', (err: Error) => {
+        if (this._isReconnecting && isTransientReconnectError(err)) {
+          this.log.appendLine(`[ESP Decoder] suppressed transient error during reconnect: ${err.message}`);
+          return;
+        }
         this._onError.fire(err);
       });
 
       this.port.on('close', (disconnectError?: Error | null) => {
+        // Cancel any pending stability check — connection didn't last.
+        this.clearStabilityTimer();
         if (disconnectError) {
-          this._onError.fire(disconnectError);
+          if (this._isReconnecting && isTransientReconnectError(disconnectError)) {
+            this.log.appendLine(`[ESP Decoder] suppressed transient close error during reconnect: ${disconnectError.message}`);
+          } else {
+            this._onError.fire(disconnectError);
+          }
         }
         this.port = null;
         if (this._isConnected) {
@@ -221,7 +253,11 @@ export class SerialPortManager extends vscode.Disposable {
 
       this.port.open((err) => {
         if (err) {
-          if (!this._suppressErrorToasts) {
+          // During an active reconnect window, treat open failures as part of
+          // the polling cycle — don't toast, don't fire the error event.
+          if (this._isReconnecting) {
+            this.log.appendLine(`[ESP Decoder] auto-reconnect: open failed, will retry: ${err.message}`);
+          } else if (!this._suppressErrorToasts) {
             vscode.window.showErrorMessage(
               `Failed to open ${this._selectedPath}: ${err.message}`
             );
@@ -240,10 +276,37 @@ export class SerialPortManager extends vscode.Disposable {
         this.captureDeviceIdentity().catch(() => {
           /* best effort — identity is only used for auto-reconnect matching */
         });
+        // If this open happened inside a reconnect window, arm the stability
+        // timer. The window only ends if the port stays open for STABILITY_MS.
+        if (this._isReconnecting) {
+          this.clearStabilityTimer();
+          this._stabilityTimer = setTimeout(() => {
+            this._stabilityTimer = null;
+            if (this._isConnected) {
+              this._isReconnecting = false;
+              this._reconnectDeadline = 0;
+              this.log.appendLine('[ESP Decoder] auto-reconnect: connection stable');
+            }
+          }, SerialPortManager.STABILITY_MS);
+        }
         this._onConnectionChange.fire(true);
         resolve(true);
       });
     });
+  }
+
+  private clearStabilityTimer(): void {
+    if (this._stabilityTimer) {
+      clearTimeout(this._stabilityTimer);
+      this._stabilityTimer = null;
+    }
+  }
+
+  private clearReconnectTimer(): void {
+    if (this._reconnectTimer) {
+      clearTimeout(this._reconnectTimer);
+      this._reconnectTimer = null;
+    }
   }
 
   /** Look up and cache VID/PID/serialNumber for the currently connected port. */
@@ -370,33 +433,48 @@ export class SerialPortManager extends vscode.Disposable {
    * @param pollIntervalMs Delay between port-list polls.
    */
   startAutoReconnect(timeoutMs: number, pollIntervalMs = 500): void {
-    if (this._reconnectTimer) {
-      // Already running — don't stack timers.
-      return;
-    }
-    if (this._isConnected) {
+    if (this._isConnected && !this._stabilityTimer) {
+      // Already stably connected — nothing to do.
       return;
     }
     if (!this._connectedVendorId && !this._connectedProductId && !this._connectedSerialNumber) {
       this.log.appendLine('[ESP Decoder] auto-reconnect skipped: no device identity captured');
+      this._isReconnecting = false;
       return;
     }
+    // Continue the existing window if one is already in progress; otherwise
+    // arm a fresh window with the supplied timeout.
+    const continuingExisting = this._isReconnecting && Date.now() < this._reconnectDeadline;
+    if (!continuingExisting) {
+      this._reconnectDeadline = Date.now() + timeoutMs;
+      this._isReconnecting = true;
+      this.log.appendLine(
+        `[ESP Decoder] auto-reconnect armed: VID=${this._connectedVendorId ?? '?'} PID=${this._connectedProductId ?? '?'} SN=${this._connectedSerialNumber ?? '?'} timeout=${timeoutMs}ms`
+      );
+    }
+    if (this._reconnectTimer) {
+      // A poll is already scheduled — don't stack timers.
+      return;
+    }
+
     const targetVid = this._connectedVendorId;
     const targetPid = this._connectedProductId;
     const targetSn = this._connectedSerialNumber;
     const previousPath = this._selectedPath;
-    this._reconnectDeadline = Date.now() + timeoutMs;
-    this.log.appendLine(
-      `[ESP Decoder] auto-reconnect armed: VID=${targetVid ?? '?'} PID=${targetPid ?? '?'} SN=${targetSn ?? '?'} timeout=${timeoutMs}ms`
-    );
 
     const poll = async (): Promise<void> => {
       this._reconnectTimer = null;
       if (this._isConnected) {
         return;
       }
+      if (!this._isReconnecting) {
+        // Cancelled externally.
+        return;
+      }
       if (Date.now() > this._reconnectDeadline) {
         this.log.appendLine('[ESP Decoder] auto-reconnect: timed out waiting for device');
+        this._isReconnecting = false;
+        this._reconnectDeadline = 0;
         return;
       }
       let ports: SerialPortInfo[] = [];
@@ -416,8 +494,8 @@ export class SerialPortManager extends vscode.Disposable {
         this._suppressErrorToasts = true;
         try {
           const ok = await this.connect();
-          if (!ok) {
-            // Open failed (device may not be fully ready) — try again.
+          if (!ok && this._isReconnecting) {
+            // Open failed (device may still be re-enumerating) — try again.
             this._reconnectTimer = setTimeout(() => { void poll(); }, pollIntervalMs);
           }
         } finally {
@@ -425,20 +503,27 @@ export class SerialPortManager extends vscode.Disposable {
         }
         return;
       }
-      this._reconnectTimer = setTimeout(() => { void poll(); }, pollIntervalMs);
+      if (this._isReconnecting) {
+        this._reconnectTimer = setTimeout(() => { void poll(); }, pollIntervalMs);
+      }
     };
 
     // First poll runs after a short delay to give the OS time to enumerate.
     this._reconnectTimer = setTimeout(() => { void poll(); }, pollIntervalMs);
   }
 
-  /** Cancel any in-flight auto-reconnect polling loop. */
+  /**
+   * Fully cancel the auto-reconnect window: stop polling, drop the deadline,
+   * and clear any pending stability check. Called by user-initiated disconnect
+   * and by dispose(). The reconnect poll itself uses {@link clearReconnectTimer}
+   * (which preserves `_isReconnecting`) so a successful open inside the poll
+   * does not abort the surrounding reconnect window.
+   */
   cancelReconnect(): void {
-    if (this._reconnectTimer) {
-      clearTimeout(this._reconnectTimer);
-      this._reconnectTimer = null;
-    }
+    this.clearReconnectTimer();
+    this.clearStabilityTimer();
     this._reconnectDeadline = 0;
+    this._isReconnecting = false;
   }
 
   dispose(): void {
@@ -454,6 +539,32 @@ export class SerialPortManager extends vscode.Disposable {
       this.log.dispose();
     }
   }
+}
+
+/**
+ * Recognises errors that the OS commonly emits while a USB-CDC device is
+ * re-enumerating (boot/reset of ESP32-S2/S3/C3, ESP32-P4, etc.) or while the
+ * user is hunting for the right CDC/JTAG port by repeatedly pressing reset.
+ * These are not actionable for the user during an active reconnect window;
+ * they're swallowed so the monitor stays quiet until either a stable
+ * connection forms or the reconnect deadline expires.
+ */
+function isTransientReconnectError(err: Error): boolean {
+  const msg = err.message.toLowerCase();
+  // POSIX: ENXIO (no such device), EIO (input/output error), ENOENT,
+  // EBADF (bad file descriptor), ENODEV (no such device), EAGAIN.
+  // macOS: "device not configured".
+  // Windows: "access denied", "operation aborted", "the device does not
+  // recognize the command", "the i/o operation has been aborted".
+  return /\b(enxio|eio|enoent|ebadf|enodev|eagain|eacces)\b/.test(msg)
+    || msg.includes('no such device')
+    || msg.includes('device not configured')
+    || msg.includes('access denied')
+    || msg.includes('operation aborted')
+    || msg.includes('i/o operation has been aborted')
+    || msg.includes('does not recognize the command')
+    || msg.includes('cannot find the file specified')
+    || msg.includes('device disconnected');
 }
 
 /**

--- a/src/test/webviewPanel.test.ts
+++ b/src/test/webviewPanel.test.ts
@@ -101,6 +101,9 @@ vi.mock('../serialPortManager.js', () => {
       onData = vi.fn(() => ({ dispose: vi.fn() }));
       onError = vi.fn(() => ({ dispose: vi.fn() }));
       onConnectionChange = vi.fn(() => ({ dispose: vi.fn() }));
+      onDisconnect = vi.fn(() => ({ dispose: vi.fn() }));
+      startAutoReconnect = vi.fn();
+      cancelReconnect = vi.fn();
       isConnected = false;
       selectedPath = undefined;
       baudRate = 115200;

--- a/src/webviewPanel.ts
+++ b/src/webviewPanel.ts
@@ -116,12 +116,14 @@ export class EspDecoderWebviewPanel implements vscode.WebviewViewProvider {
     // Auto-reconnect on unexpected disconnects (e.g. native USB-CDC reset)
     this.disposables.push(
       this.serialManager.onDisconnect((info) => {
+        this.logDebug(`[ESP Decoder] onDisconnect: userInitiated=${info.userInitiated} suspended=${info.suspended}`);
         if (info.userInitiated || info.suspended) {
           return;
         }
         const cfg = vscode.workspace.getConfiguration('esp-decoder');
         const enabled = cfg.get<boolean>('serialMonitor.autoReconnect', false);
         if (!enabled) {
+          this.logDebug('[ESP Decoder] auto-reconnect disabled (esp-decoder.serialMonitor.autoReconnect=false) — not reconnecting');
           return;
         }
         const timeoutMs = cfg.get<number>('serialMonitor.autoReconnectTimeoutMs', 15000);
@@ -974,6 +976,17 @@ export class EspDecoderWebviewPanel implements vscode.WebviewViewProvider {
       })),
       rawOutput: result.rawOutput,
     };
+  }
+
+  /**
+   * Append a diagnostic line to the output channel only when
+   * `esp-decoder.debugLogging` is enabled. Use for verbose internal-state
+   * messages that are noise during normal use but useful for troubleshooting.
+   */
+  private logDebug(message: string): void {
+    if (vscode.workspace.getConfiguration('esp-decoder').get<boolean>('debugLogging', false)) {
+      this.log.appendLine(message);
+    }
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/webviewPanel.ts
+++ b/src/webviewPanel.ts
@@ -113,6 +113,23 @@ export class EspDecoderWebviewPanel implements vscode.WebviewViewProvider {
       })
     );
 
+    // Auto-reconnect on unexpected disconnects (e.g. native USB-CDC reset)
+    this.disposables.push(
+      this.serialManager.onDisconnect((info) => {
+        if (info.userInitiated || info.suspended) {
+          return;
+        }
+        const cfg = vscode.workspace.getConfiguration('esp-decoder');
+        const enabled = cfg.get<boolean>('serialMonitor.autoReconnect', false);
+        if (!enabled) {
+          return;
+        }
+        const timeoutMs = cfg.get<number>('serialMonitor.autoReconnectTimeoutMs', 15000);
+        this.log.appendLine(`[ESP Decoder] Unexpected disconnect — starting auto-reconnect (timeout ${timeoutMs}ms)`);
+        this.serialManager.startAutoReconnect(timeoutMs);
+      })
+    );
+
     // Listen to crash events from trbr's capturer
     this.disposables.push(
       this.crashCapturer.onCrashDetected(async (event) => {


### PR DESCRIPTION
* **New Features**
  * Auto-reconnect for unexpected serial monitor disconnections (configurable, off by default).
  * Settings: enable/disable auto-reconnect and set timeout (ms, default 15000).
  * Auto-reconnect only triggers for unexpected disconnects; user-initiated or suspended disconnects are ignored.
