### PR TITLE
Replace CLI Monitor with ESP Decoder Terminal in used target "Upload and Monitor"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.26.0] - 2026-05-09
+
+### Added
+- **"Upload and Monitor" task interception** — when pioarduino runs its combined "Upload and Monitor" task, ESP Decoder now intercepts it before the CLI monitor can open (#52).
+  - The combined task is terminated immediately; a synthetic upload-only task (with `--target monitor` stripped) runs in its place.
+  - On successful upload (exit code `0`), `esp-decoder.openMonitor` is called with `autoConnect: true`, replacing the CLI terminal with the ESP Decoder serial monitor.
+  - Baud rate is resolved automatically from `monitor_speed` in `platformio.ini` via a new `getMonitorBaudRate()` helper in `pioIntegration.ts`.
+  - Spurious `onDidUpload` events fired when the combined task is killed are suppressed via `suppressingCombinedTask` + `syntheticUploadExecutions` guards to prevent unwanted port reacquisition.
+  - A 10 s safety timeout ensures the synthetic upload starts even if the original task is slow to terminate.
+  - Retry-based port reacquisition (5 attempts, linear back-off from 300 ms) handles OS-level USB device hold after flashing.
+
 ## [0.25.0] - 2026-05-08
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@typescript-eslint/parser": "^8.58.2",
         "esbuild": "^0.28.0",
         "eslint": "^10.2.0",
-        "pioarduino-node-helpers": "^12.4.4",
+        "pioarduino-node-helpers": "^12.6.0",
         "typescript": "6.0.2",
         "vitest": "^4.1.4"
       },
@@ -3031,9 +3031,9 @@
       }
     },
     "node_modules/pioarduino-node-helpers": {
-      "version": "12.4.4",
-      "resolved": "https://registry.npmjs.org/pioarduino-node-helpers/-/pioarduino-node-helpers-12.4.4.tgz",
-      "integrity": "sha512-u4ACbMm+qdOtUVuprIaX8f4VG1a6px3Qc6Vsd+pFpuHgHtOxTGYKUhte6LiSdKjbqA1FxBaQaQOBAzy2oJtKeQ==",
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/pioarduino-node-helpers/-/pioarduino-node-helpers-12.6.0.tgz",
+      "integrity": "sha512-jq30kJNNZO3tXhnkdtVaUogyLvSURbpDLEw/4CDIXaZgq5p4aQg+nbzrVYAhuANZ2AYOzVs8GLbdotSGIntg7A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "esp-decoder",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "esp-decoder",
-      "version": "0.25.0",
+      "version": "0.26.0",
       "license": "GPL-3.0",
       "dependencies": {
         "serialport": "^13.0.0"

--- a/package.json
+++ b/package.json
@@ -234,7 +234,7 @@
     "@typescript-eslint/parser": "^8.58.2",
     "esbuild": "^0.28.0",
     "eslint": "^10.2.0",
-    "pioarduino-node-helpers": "^12.4.4",
+    "pioarduino-node-helpers": "^12.6.0",
     "typescript": "6.0.2",
     "vitest": "^4.1.4"
   }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "esp-decoder",
   "displayName": "ESP Crash Decoder",
   "description": "Decode ESP32 / ESP8266 crash dumps from serial port",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "publisher": "Jason2866",
   "license": "GPL-3.0",
   "icon": "assets/icon_large.png",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -424,6 +424,47 @@ function findEspIdfProjectRoot(elfPath: string, workspaceFolder: string): string
   }
 }
 
+/** PlatformIO task provider type used by pioarduino IDE. */
+const PIO_TASK_TYPE = 'PlatformIO';
+
+/**
+ * Tracks currently running PlatformIO "Upload and Monitor" task executions.
+ * Keyed by the task definition `task` id so we can cancel them after a
+ * successful upload and open the ESP-Decoder monitor instead of letting
+ * pioarduino spawn its built-in CLI monitor in the terminal.
+ */
+const activeUploadAndMonitorTasks = new Map<string, vscode.TaskExecution>();
+
+/**
+ * Detect whether a VSCode task is pioarduino's "Upload and Monitor" task.
+ *
+ * pioarduino exposes two surface markers:
+ *  - definition.type === 'PlatformIO'
+ *  - the task name (e.g. `Upload and Monitor`) and/or task args contain both
+ *    `--target upload` and `--target monitor`.
+ *
+ * The task name is localizable in newer pioarduino versions, so we look at
+ * both the name and (when available) the underlying ProcessExecution args.
+ */
+function isPioUploadAndMonitorTask(task: vscode.Task): boolean {
+  if (task.definition?.type !== PIO_TASK_TYPE) {
+    return false;
+  }
+  if (/upload\s*and\s*monitor/i.test(task.name)) {
+    return true;
+  }
+  const execution = task.execution;
+  if (execution instanceof vscode.ProcessExecution) {
+    const args = execution.args ?? [];
+    const hasUploadTarget = args.some((arg, i) => arg === '--target' && args[i + 1] === 'upload');
+    const hasMonitorTarget = args.some((arg, i) => arg === '--target' && args[i + 1] === 'monitor');
+    if (hasUploadTarget && hasMonitorTarget) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /**
  * Subscribe to pioarduino IDE upload lifecycle events.
  *
@@ -439,12 +480,48 @@ function findEspIdfProjectRoot(elfPath: string, workspaceFolder: string): string
  *  - Retry-based reacquire: instead of a fixed delay we try to reconnect
  *    immediately and retry with short back-off if the OS hasn't released the
  *    device yet.
+ *
+ * Additionally, we hook VSCode's task lifecycle to intercept pioarduino's
+ * "Upload and Monitor" task: pioarduino runs upload+monitor as a single
+ * `pio run --target upload --target monitor` invocation, so its built-in
+ * CLI monitor would normally start in the integrated terminal once the
+ * upload finishes.  When ESP-Decoder is installed users expect the same
+ * decoder-aware monitor as for the standalone "Monitor" task.  We therefore
+ * remember the active upload-and-monitor execution, and on a successful
+ * upload (`onDidUpload` with exitCode 0) terminate that task and open
+ * `esp-decoder.openMonitor` with auto-connect — mirroring what pioarduino
+ * already does internally for the plain "Monitor" task.
  */
 function subscribeToPioarduinoEvents(
   context: vscode.ExtensionContext,
   serial: SerialPortManager,
   log: vscode.OutputChannel,
 ): void {
+  // Track running PlatformIO "Upload and Monitor" task executions so we can
+  // intercept them once the upload phase completes successfully.
+  context.subscriptions.push(
+    vscode.tasks.onDidStartTask((event) => {
+      const task = event.execution.task;
+      if (!isPioUploadAndMonitorTask(task)) {
+        return;
+      }
+      const taskId = String(task.definition?.task ?? task.name);
+      activeUploadAndMonitorTasks.set(taskId, event.execution);
+      log.appendLine(`[ESP Decoder] Tracking "Upload and Monitor" task: ${task.name} (${taskId})`);
+    }),
+  );
+
+  context.subscriptions.push(
+    vscode.tasks.onDidEndTask((event) => {
+      const task = event.execution.task;
+      if (task.definition?.type !== PIO_TASK_TYPE) {
+        return;
+      }
+      const taskId = String(task.definition?.task ?? task.name);
+      activeUploadAndMonitorTasks.delete(taskId);
+    }),
+  );
+
   const pioExt = vscode.extensions.getExtension<PioarduinoApi>('pioarduino.pioarduino-ide');
   if (!pioExt) {
     log.appendLine('[ESP Decoder] pioarduino IDE extension not found — upload events unavailable');
@@ -489,8 +566,41 @@ function subscribeToPioarduinoEvents(
     context.subscriptions.push(
       api.onDidUpload(async ({ port, exitCode }) => {
         log.appendLine(
-          `[ESP Decoder] onDidUpload (port=${port ?? 'auto'}, exitCode=${exitCode}) — reacquiring serial port`,
+          `[ESP Decoder] onDidUpload (port=${port ?? 'auto'}, exitCode=${exitCode})`,
         );
+
+        // If this upload was part of an "Upload and Monitor" task and the
+        // upload phase succeeded, terminate the task before pioarduino's
+        // built-in CLI monitor takes over the serial port, then open the
+        // ESP-Decoder monitor (same handover semantics that pioarduino
+        // already implements for the plain "Monitor" task).
+        if (exitCode === 0 && activeUploadAndMonitorTasks.size > 0) {
+          const handoverPort = port || serial.selectedPath;
+          for (const [taskId, execution] of [...activeUploadAndMonitorTasks]) {
+            log.appendLine(
+              `[ESP Decoder] Intercepting "Upload and Monitor" task (${taskId}) — opening ESP Decoder monitor instead of CLI monitor`,
+            );
+            try {
+              execution.terminate();
+            } catch (err) {
+              log.appendLine(`[ESP Decoder] Failed to terminate task ${taskId}: ${err}`);
+            }
+            activeUploadAndMonitorTasks.delete(taskId);
+          }
+          try {
+            await vscode.commands.executeCommand('esp-decoder.openMonitor', {
+              port: handoverPort,
+              autoConnect: true,
+            });
+          } catch (err) {
+            log.appendLine(`[ESP Decoder] Failed to open monitor after upload: ${err}`);
+          }
+          return;
+        }
+
+        // Plain upload (or upload failed): just reacquire the port for the
+        // already-open monitor.
+        log.appendLine('[ESP Decoder] Reacquiring serial port');
         await reacquireWithRetry(serial, log);
       }),
     );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -436,12 +436,21 @@ const PIO_TASK_TYPE = 'PlatformIO';
 const INTERCEPTED_TASK_MARKER = '__espDecoderInterceptedUpload__';
 
 /**
- * True while we are in the middle of replacing pioarduino's combined
- * "Upload and Monitor" task with our own upload-only task.  Used to
- * suppress the spurious `onDidUpload(exitCode != 0)` event that pioarduino
- * fires when we terminate the original combined task.
+ * Tracks synthetic upload-only TaskExecutions created by ESP-Decoder when
+ * intercepting a pioarduino "Upload and Monitor" task.  An execution is
+ * present from the moment executeTask() resolves until after openMonitor /
+ * reacquireWithRetry completes, ensuring pioarduino's onDidUpload is
+ * suppressed for the entire handover window.
  */
-let interceptionInProgress = false;
+const syntheticUploadExecutions = new Set<vscode.TaskExecution>();
+
+/**
+ * True during the brief gap between terminate() of the combined task and
+ * the synthetic task execution being added to syntheticUploadExecutions.
+ * Prevents pioarduino's spurious onDidUpload(exitCode != 0) from slipping
+ * through during that window.
+ */
+let suppressingCombinedTask = false;
 
 /**
  * Detect whether a VSCode task is pioarduino's "Upload and Monitor" task.
@@ -572,21 +581,41 @@ function subscribeToPioarduinoEvents(
         `[ESP Decoder] Intercepting "${task.name}" — running upload only, then opening ESP Decoder monitor`,
       );
 
+      // Register the end listener BEFORE calling terminate() to avoid a race
+      // where onDidEndTask fires before we start listening.
+      const origExecution = event.execution;
+      const originalTaskEnded = new Promise<void>((resolve) => {
+        const sub = vscode.tasks.onDidEndTask((endEvent) => {
+          if (endEvent.execution === origExecution) {
+            sub.dispose();
+            resolve();
+          }
+        });
+        // Safety: resolve after 5 s if onDidEndTask never fires (e.g. window reload).
+        setTimeout(() => { sub.dispose(); resolve(); }, 5_000);
+      });
+
       // Suppress the bogus onDidUpload(exitCode != 0) that pioarduino will
       // fire when we terminate the combined task below.
-      interceptionInProgress = true;
+      suppressingCombinedTask = true;
 
       try {
-        event.execution.terminate();
+        origExecution.terminate();
       } catch (err) {
         log.appendLine(`[ESP Decoder] Failed to terminate combined task: ${err}`);
       }
 
+      // Wait for the original task to fully exit so two pio run processes
+      // never contend for the serial port simultaneously.
+      await originalTaskEnded;
+
       try {
-        await vscode.tasks.executeTask(uploadOnly);
+        const execution = await vscode.tasks.executeTask(uploadOnly);
+        syntheticUploadExecutions.add(execution);
+        suppressingCombinedTask = false;
       } catch (err) {
         log.appendLine(`[ESP Decoder] Failed to launch upload-only replacement task: ${err}`);
-        interceptionInProgress = false;
+        suppressingCombinedTask = false;
       }
     }),
   );
@@ -603,7 +632,6 @@ function subscribeToPioarduinoEvents(
       log.appendLine(
         `[ESP Decoder] Intercepted upload-only task ended (exitCode=${event.exitCode})`,
       );
-      interceptionInProgress = false;
 
       if (event.exitCode === 0) {
         try {
@@ -620,6 +648,21 @@ function subscribeToPioarduinoEvents(
         // Upload failed (or was cancelled): try to reacquire the port so any
         // already-open monitor keeps working.
         await reacquireWithRetry(serial, log);
+      }
+
+      // Clear suppression only after handover operations complete, so any
+      // pioarduino onDidUpload for the synthetic task is still suppressed.
+      syntheticUploadExecutions.delete(event.execution);
+    }),
+  );
+
+  // Fallback cleanup: remove synthetic executions that ended without
+  // onDidEndTaskProcess firing (e.g., task was cancelled before the process
+  // started).  Set.delete is a no-op for executions already removed above.
+  context.subscriptions.push(
+    vscode.tasks.onDidEndTask((event) => {
+      if (event.execution.task.definition?.[INTERCEPTED_TASK_MARKER]) {
+        syntheticUploadExecutions.delete(event.execution);
       }
     }),
   );
@@ -671,9 +714,9 @@ function subscribeToPioarduinoEvents(
         // terminate the combined "Upload and Monitor" task as part of the
         // early-intercept flow above.  The synthetic upload-only task
         // handles its own lifecycle via onDidEndTaskProcess.
-        if (interceptionInProgress) {
+        if (suppressingCombinedTask || syntheticUploadExecutions.size > 0) {
           log.appendLine(
-            `[ESP Decoder] Ignoring onDidUpload (exitCode=${exitCode}) from intercepted combined task`,
+            `[ESP Decoder] Ignoring onDidUpload (exitCode=${exitCode}) — intercepted upload in progress`,
           );
           return;
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -95,8 +95,18 @@ export function activate(context: vscode.ExtensionContext) {
         if (opts?.port) {
           serialManager.setPort(opts.port);
         }
-        if (typeof opts?.baudRate === 'number') {
-          serialManager.setBaudRate(opts.baudRate);
+        // If the caller did not supply a baud rate, look it up from
+        // platformio.ini via pioarduino-node-helpers so the project's
+        // monitor_speed is always honoured without the user having to
+        // configure it a second time inside ESP Decoder.
+        const resolvedBaudRate = typeof opts?.baudRate === 'number'
+          ? opts.baudRate
+          : await (async () => {
+              const folder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+              return folder ? await getMonitorBaudRate(folder) : undefined;
+            })();
+        if (typeof resolvedBaudRate === 'number') {
+          serialManager.setBaudRate(resolvedBaudRate);
         }
 
         if (viewProvider) {
@@ -120,7 +130,7 @@ export function activate(context: vscode.ExtensionContext) {
             const portChanged =
               !!opts?.port && opts.port !== prevPort;
             const baudChanged =
-              typeof opts?.baudRate === 'number' && opts.baudRate !== prevBaud;
+              typeof resolvedBaudRate === 'number' && resolvedBaudRate !== prevBaud;
             if (serialManager.isConnected && (portChanged || baudChanged)) {
               await serialManager.disconnect();
             }
@@ -635,16 +645,8 @@ function subscribeToPioarduinoEvents(
 
       if (event.exitCode === 0) {
         try {
-          const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-          const baudRate = workspaceFolder
-            ? await getMonitorBaudRate(workspaceFolder)
-            : undefined;
-          if (baudRate !== undefined) {
-            log.appendLine(`[ESP Decoder] Using monitor_speed=${baudRate} from pioarduino config`);
-          }
           await vscode.commands.executeCommand('esp-decoder.openMonitor', {
             port: serial.selectedPath,
-            ...(baudRate !== undefined ? { baudRate } : {}),
             autoConnect: true,
           });
         } catch (err) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -99,12 +99,11 @@ export function activate(context: vscode.ExtensionContext) {
         // platformio.ini via pioarduino-node-helpers so the project's
         // monitor_speed is always honoured without the user having to
         // configure it a second time inside ESP Decoder.
-        const resolvedBaudRate = typeof opts?.baudRate === 'number'
-          ? opts.baudRate
-          : await (async () => {
-              const folder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-              return folder ? await getMonitorBaudRate(folder) : undefined;
-            })();
+        let resolvedBaudRate: number | undefined = opts?.baudRate;
+        if (typeof resolvedBaudRate !== 'number') {
+          const folder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+          resolvedBaudRate = folder ? await getMonitorBaudRate(folder) : undefined;
+        }
         if (typeof resolvedBaudRate === 'number') {
           serialManager.setBaudRate(resolvedBaudRate);
         }
@@ -601,8 +600,14 @@ function subscribeToPioarduinoEvents(
             resolve();
           }
         });
-        // Safety: resolve after 5 s if onDidEndTask never fires (e.g. window reload).
-        setTimeout(() => { sub.dispose(); resolve(); }, 5_000);
+        // Safety: resolve after 10 s if onDidEndTask never fires (e.g. window reload).
+        setTimeout(() => {
+          sub.dispose();
+          log.appendLine(
+            '[ESP Decoder] Original combined task did not end within 10 s — proceeding anyway',
+          );
+          resolve();
+        }, 10_000);
       });
 
       // Suppress the bogus onDidUpload(exitCode != 0) that pioarduino will

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -428,12 +428,20 @@ function findEspIdfProjectRoot(elfPath: string, workspaceFolder: string): string
 const PIO_TASK_TYPE = 'PlatformIO';
 
 /**
- * Tracks currently running PlatformIO "Upload and Monitor" task executions.
- * Keyed by the task definition `task` id so we can cancel them after a
- * successful upload and open the ESP-Decoder monitor instead of letting
- * pioarduino spawn its built-in CLI monitor in the terminal.
+ * Marker added to task definitions of synthetic upload-only tasks created
+ * by ESP-Decoder when intercepting a pioarduino "Upload and Monitor" task.
+ * Used to recognise our own task in the task lifecycle hooks (so we don't
+ * recurse) and to know when to open the ESP-Decoder monitor afterwards.
  */
-const activeUploadAndMonitorTasks = new Map<string, vscode.TaskExecution>();
+const INTERCEPTED_TASK_MARKER = '__espDecoderInterceptedUpload__';
+
+/**
+ * True while we are in the middle of replacing pioarduino's combined
+ * "Upload and Monitor" task with our own upload-only task.  Used to
+ * suppress the spurious `onDidUpload(exitCode != 0)` event that pioarduino
+ * fires when we terminate the original combined task.
+ */
+let interceptionInProgress = false;
 
 /**
  * Detect whether a VSCode task is pioarduino's "Upload and Monitor" task.
@@ -448,6 +456,9 @@ const activeUploadAndMonitorTasks = new Map<string, vscode.TaskExecution>();
  */
 function isPioUploadAndMonitorTask(task: vscode.Task): boolean {
   if (task.definition?.type !== PIO_TASK_TYPE) {
+    return false;
+  }
+  if (task.definition?.[INTERCEPTED_TASK_MARKER]) {
     return false;
   }
   if (/upload\s*and\s*monitor/i.test(task.name)) {
@@ -466,6 +477,48 @@ function isPioUploadAndMonitorTask(task: vscode.Task): boolean {
 }
 
 /**
+ * Build a synthetic "upload-only" Task by cloning the given pioarduino
+ * "Upload and Monitor" task and stripping the `--target monitor` arguments
+ * from its ProcessExecution.  Returns undefined if the task uses an
+ * unsupported execution type.
+ */
+function buildUploadOnlyTask(original: vscode.Task): vscode.Task | undefined {
+  const execution = original.execution;
+  if (!(execution instanceof vscode.ProcessExecution)) {
+    return undefined;
+  }
+
+  const newArgs: string[] = [];
+  const args = execution.args ?? [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--target' && args[i + 1] === 'monitor') {
+      i++; // also skip the literal "monitor"
+      continue;
+    }
+    newArgs.push(String(args[i]));
+  }
+
+  const definition = {
+    ...original.definition,
+    [INTERCEPTED_TASK_MARKER]: true,
+  };
+
+  const uploadOnly = new vscode.Task(
+    definition,
+    original.scope ?? vscode.TaskScope.Workspace,
+    original.name,
+    original.source,
+    new vscode.ProcessExecution(execution.process, newArgs, execution.options),
+    original.problemMatchers,
+  );
+  uploadOnly.presentationOptions = original.presentationOptions;
+  if (original.group) {
+    uploadOnly.group = original.group;
+  }
+  return uploadOnly;
+}
+
+/**
  * Subscribe to pioarduino IDE upload lifecycle events.
  *
  * When pioarduino starts an upload (flash) we release the serial port so the
@@ -481,44 +534,93 @@ function isPioUploadAndMonitorTask(task: vscode.Task): boolean {
  *    immediately and retry with short back-off if the OS hasn't released the
  *    device yet.
  *
- * Additionally, we hook VSCode's task lifecycle to intercept pioarduino's
- * "Upload and Monitor" task: pioarduino runs upload+monitor as a single
+ * Additionally, we intercept pioarduino's "Upload and Monitor" task as
+ * early as possible: pioarduino runs upload+monitor as a single
  * `pio run --target upload --target monitor` invocation, so its built-in
  * CLI monitor would normally start in the integrated terminal once the
- * upload finishes.  When ESP-Decoder is installed users expect the same
- * decoder-aware monitor as for the standalone "Monitor" task.  We therefore
- * remember the active upload-and-monitor execution, and on a successful
- * upload (`onDidUpload` with exitCode 0) terminate that task and open
- * `esp-decoder.openMonitor` with auto-connect — mirroring what pioarduino
- * already does internally for the plain "Monitor" task.
+ * upload finishes — and `onDidUpload` only fires after the user closes
+ * that monitor again.  We therefore listen on `vscode.tasks.onDidStartTask`,
+ * cancel the combined task immediately, and re-launch a synthetic
+ * upload-only task in its place.  When that synthetic task ends with
+ * exitCode 0 we open `esp-decoder.openMonitor` with auto-connect — same
+ * handover semantics that pioarduino already implements for the standalone
+ * "Monitor" task.
  */
 function subscribeToPioarduinoEvents(
   context: vscode.ExtensionContext,
   serial: SerialPortManager,
   log: vscode.OutputChannel,
 ): void {
-  // Track running PlatformIO "Upload and Monitor" task executions so we can
-  // intercept them once the upload phase completes successfully.
+  // Early intercept: replace "Upload and Monitor" with upload-only as soon
+  // as pioarduino starts the combined task, so the CLI monitor never opens.
   context.subscriptions.push(
-    vscode.tasks.onDidStartTask((event) => {
+    vscode.tasks.onDidStartTask(async (event) => {
       const task = event.execution.task;
       if (!isPioUploadAndMonitorTask(task)) {
         return;
       }
-      const taskId = String(task.definition?.task ?? task.name);
-      activeUploadAndMonitorTasks.set(taskId, event.execution);
-      log.appendLine(`[ESP Decoder] Tracking "Upload and Monitor" task: ${task.name} (${taskId})`);
+
+      const uploadOnly = buildUploadOnlyTask(task);
+      if (!uploadOnly) {
+        log.appendLine(
+          `[ESP Decoder] Cannot intercept "${task.name}": unsupported task execution type`,
+        );
+        return;
+      }
+
+      log.appendLine(
+        `[ESP Decoder] Intercepting "${task.name}" — running upload only, then opening ESP Decoder monitor`,
+      );
+
+      // Suppress the bogus onDidUpload(exitCode != 0) that pioarduino will
+      // fire when we terminate the combined task below.
+      interceptionInProgress = true;
+
+      try {
+        event.execution.terminate();
+      } catch (err) {
+        log.appendLine(`[ESP Decoder] Failed to terminate combined task: ${err}`);
+      }
+
+      try {
+        await vscode.tasks.executeTask(uploadOnly);
+      } catch (err) {
+        log.appendLine(`[ESP Decoder] Failed to launch upload-only replacement task: ${err}`);
+        interceptionInProgress = false;
+      }
     }),
   );
 
+  // When our synthetic upload-only task ends, open ESP Decoder (success)
+  // or fall back to reacquiring the port for monitoring (failure).
   context.subscriptions.push(
-    vscode.tasks.onDidEndTask((event) => {
+    vscode.tasks.onDidEndTaskProcess(async (event) => {
       const task = event.execution.task;
-      if (task.definition?.type !== PIO_TASK_TYPE) {
+      if (!task.definition?.[INTERCEPTED_TASK_MARKER]) {
         return;
       }
-      const taskId = String(task.definition?.task ?? task.name);
-      activeUploadAndMonitorTasks.delete(taskId);
+
+      log.appendLine(
+        `[ESP Decoder] Intercepted upload-only task ended (exitCode=${event.exitCode})`,
+      );
+      interceptionInProgress = false;
+
+      if (event.exitCode === 0) {
+        try {
+          await vscode.commands.executeCommand('esp-decoder.openMonitor', {
+            port: serial.selectedPath,
+            autoConnect: true,
+          });
+        } catch (err) {
+          log.appendLine(
+            `[ESP Decoder] Failed to open monitor after intercepted upload: ${err}`,
+          );
+        }
+      } else {
+        // Upload failed (or was cancelled): try to reacquire the port so any
+        // already-open monitor keeps working.
+        await reacquireWithRetry(serial, log);
+      }
     }),
   );
 
@@ -565,42 +667,20 @@ function subscribeToPioarduinoEvents(
 
     context.subscriptions.push(
       api.onDidUpload(async ({ port, exitCode }) => {
-        log.appendLine(
-          `[ESP Decoder] onDidUpload (port=${port ?? 'auto'}, exitCode=${exitCode})`,
-        );
-
-        // If this upload was part of an "Upload and Monitor" task and the
-        // upload phase succeeded, terminate the task before pioarduino's
-        // built-in CLI monitor takes over the serial port, then open the
-        // ESP-Decoder monitor (same handover semantics that pioarduino
-        // already implements for the plain "Monitor" task).
-        if (exitCode === 0 && activeUploadAndMonitorTasks.size > 0) {
-          const handoverPort = port || serial.selectedPath;
-          for (const [taskId, execution] of [...activeUploadAndMonitorTasks]) {
-            log.appendLine(
-              `[ESP Decoder] Intercepting "Upload and Monitor" task (${taskId}) — opening ESP Decoder monitor instead of CLI monitor`,
-            );
-            try {
-              execution.terminate();
-            } catch (err) {
-              log.appendLine(`[ESP Decoder] Failed to terminate task ${taskId}: ${err}`);
-            }
-            activeUploadAndMonitorTasks.delete(taskId);
-          }
-          try {
-            await vscode.commands.executeCommand('esp-decoder.openMonitor', {
-              port: handoverPort,
-              autoConnect: true,
-            });
-          } catch (err) {
-            log.appendLine(`[ESP Decoder] Failed to open monitor after upload: ${err}`);
-          }
+        // Suppress the spurious upload event that pioarduino fires when we
+        // terminate the combined "Upload and Monitor" task as part of the
+        // early-intercept flow above.  The synthetic upload-only task
+        // handles its own lifecycle via onDidEndTaskProcess.
+        if (interceptionInProgress) {
+          log.appendLine(
+            `[ESP Decoder] Ignoring onDidUpload (exitCode=${exitCode}) from intercepted combined task`,
+          );
           return;
         }
 
-        // Plain upload (or upload failed): just reacquire the port for the
-        // already-open monitor.
-        log.appendLine('[ESP Decoder] Reacquiring serial port');
+        log.appendLine(
+          `[ESP Decoder] onDidUpload (port=${port ?? 'auto'}, exitCode=${exitCode}) — reacquiring serial port`,
+        );
         await reacquireWithRetry(serial, log);
       }),
     );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { SerialPortManager } from './serialPortManager';
 import { EspDecoderWebviewPanel, SessionConfig } from './webviewPanel';
-import { findPioEnvironments, selectElfFile } from './pioIntegration';
+import { findPioEnvironments, selectElfFile, getMonitorBaudRate } from './pioIntegration';
 import { findEspIdfBuilds } from './espIdfIntegration';
 
 /** Shape of the public API exported by the pioarduino IDE extension. */
@@ -635,8 +635,16 @@ function subscribeToPioarduinoEvents(
 
       if (event.exitCode === 0) {
         try {
+          const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+          const baudRate = workspaceFolder
+            ? await getMonitorBaudRate(workspaceFolder)
+            : undefined;
+          if (baudRate !== undefined) {
+            log.appendLine(`[ESP Decoder] Using monitor_speed=${baudRate} from pioarduino config`);
+          }
           await vscode.commands.executeCommand('esp-decoder.openMonitor', {
             port: serial.selectedPath,
+            ...(baudRate !== undefined ? { baudRate } : {}),
             autoConnect: true,
           });
         } catch (err) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -603,9 +603,6 @@ function subscribeToPioarduinoEvents(
         // Safety: resolve after 10 s if onDidEndTask never fires (e.g. window reload).
         setTimeout(() => {
           sub.dispose();
-          log.appendLine(
-            '[ESP Decoder] Original combined task did not end within 10 s — proceeding anyway',
-          );
           resolve();
         }, 10_000);
       });

--- a/src/pioIntegration.ts
+++ b/src/pioIntegration.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
 import { findEspIdfBuilds } from './espIdfIntegration';
-import { core as pioCore } from 'pioarduino-node-helpers';
+import { core as pioCore, project as pioProject } from 'pioarduino-node-helpers';
 import { CHIP_TARGET_MAP, RISCV_TARGETS } from './chipTargets';
 
 /**
@@ -578,8 +578,7 @@ function resolveBuildDir(workspaceFolder: string, sections: Sections): string {
  */
 export async function getMonitorBaudRate(projectPath: string): Promise<number | undefined> {
   try {
-    const { ProjectConfig } = (await import('pioarduino-node-helpers')).project;
-    const config = new ProjectConfig(projectPath);
+    const config = new pioProject.ProjectConfig(projectPath);
     await config.read();
     return config.getEnvMonitorSpeed(config.defaultEnv());
   } catch {

--- a/src/pioIntegration.ts
+++ b/src/pioIntegration.ts
@@ -571,6 +571,24 @@ function resolveBuildDir(workspaceFolder: string, sections: Sections): string {
 // ---------------------------------------------------------------------------
 
 /**
+ * Read the `monitor_speed` value for the given PlatformIO environment using
+ * the ProjectConfig API from pioarduino-node-helpers.
+ * Returns `undefined` when PIO Core is unavailable, the key is absent, or
+ * the env is not found in the project config.
+ */
+export async function getMonitorBaudRate(projectPath: string): Promise<number | undefined> {
+  try {
+    const { ProjectConfig } = (await import('pioarduino-node-helpers')).project;
+    const config = new ProjectConfig(projectPath);
+    await config.read();
+    return config.getEnvMonitorSpeed(config.defaultEnv());
+  } catch {
+    // PIO Core not available or project not configured — ignore
+  }
+  return undefined;
+}
+
+/**
  * Find PlatformIO build environments in the workspace.
  * Uses the full INI parser with extra_configs, extends, and variable
  * interpolation support. Searches for all .elf files in build directories,

--- a/src/pioarduino-node-helpers.d.ts
+++ b/src/pioarduino-node-helpers.d.ts
@@ -5,4 +5,14 @@ declare module 'pioarduino-node-helpers' {
     getEnvDir(): string;
     getEnvBinDir(): string;
   };
+  export const project: {
+    ProjectConfig: new (projectDir: string) => {
+      read(): Promise<void>;
+      envs(): string[];
+      defaultEnvs(): string[];
+      defaultEnv(): string;
+      getEnvPlatform(env: string): string | null;
+      getEnvMonitorSpeed(env: string): number | undefined;
+    };
+  };
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced upload-and-monitor workflow for ESP devices with improved task orchestration
  * Automatic monitor connection after successful uploads, using project-configured baud rate

* **Bug Fixes**
  * Prevents spurious/duplicate upload events that conflicted with monitoring
  * More reliable serial-port recovery and reconnection after interrupted operations

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Jason2866/ESP-Decoder/pull/52)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->