### PR TITLE
fix: maybe width is calculated wrong

### DIFF
--- a/src/webviewPanel.ts
+++ b/src/webviewPanel.ts
@@ -1066,6 +1066,8 @@ export class EspDecoderWebviewPanel implements vscode.WebviewViewProvider {
       display: flex;
       flex-direction: column;
       overflow: hidden;
+      padding: 0;
+      margin: 0;
     }
 
     /* Toolbar */
@@ -1214,6 +1216,7 @@ export class EspDecoderWebviewPanel implements vscode.WebviewViewProvider {
     #serial-output {
       flex: 1;
       overflow-y: auto;
+      overflow-x: hidden;
       padding: 4px 8px;
       font-family: var(--vscode-editor-font-family, 'Courier New', monospace);
       font-size: var(--vscode-editor-font-size, 13px);


### PR DESCRIPTION
@coderabbitai does this PR fix https://github.com/Jason2866/ESP-Decoder/issues/53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the visual layout and display of the serial monitor output interface by adjusting spacing and ensuring content renders properly without unwanted horizontal overflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Jason2866/ESP-Decoder/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->